### PR TITLE
Bug/destroy immediate

### DIFF
--- a/include/Scene.h
+++ b/include/Scene.h
@@ -29,14 +29,29 @@ namespace SimpleECS
 		bool SIMPLEECS_API AddEntity(Entity* entity);
 
 		/**
-		* Destroy entity contained by this scene. Will call entity and component destructors
-		* and entityToDelete will be deleted.
+		* Destroy entity contained by this scene IMMEDIATELY. Proceed with caution, as
+		* references can be broken 
 		* 
 		* @returns false if entity is not contained by the scene and was not deleted. 
 		* Otherwise returns true if successfuly removed.
 		* 
 		*/
+		bool SIMPLEECS_API DestroyEntityImmediate(Entity* entityToDelete);
+
+		/**
+		* Mark entity to be deleted at end of frame. Will call entity and component destructors
+		* and entityToDelete will be deleted.
+		*
+		* @returns false if entity is not contained by the scene and was not deleted.
+		* Otherwise returns true if successfuly removed.
+		*
+		*/
 		bool SIMPLEECS_API DestroyEntity(Entity* entityToDelete);
+
+		/**
+		*  Immediately destroys all entities marked for destruction (i.e. in toDestroyEntities)/
+		*/
+		void DestroyAllMarkedEntities();
 
 		/*
 		* Main background render color.
@@ -47,5 +62,12 @@ namespace SimpleECS
 		* Main background render color.
 		*/
 		std::unordered_set<Entity*> entities;
+
+		private:
+		
+		/*
+		* Entities marked for destruction. Cleared at end of every frame to be deleted.
+		*/
+		std::unordered_set<Entity*> toDestroyEntities;
 	};
 }

--- a/src/ColliderSystem.cpp
+++ b/src/ColliderSystem.cpp
@@ -74,37 +74,40 @@ void SimpleECS::ColliderSystem::invokeCollisions()
 	// Populate with potential pairs from main scene
 	for (int i = 0; i < colliderGrid.size(); ++i)
 	{
-		for (auto& colliderA : colliderGrid.getCellContents(i))
+		// TODO: Idea - instead of iterating through all, change potentialPairs to be unique
+		// by order so iteration will only insert unique ordered pairs.
+		for (const auto& colliderA : colliderGrid.getCellContents(i))
 		{
-			for (auto& colliderB : colliderGrid.getCellContents(i))
+			for (const auto& colliderB : colliderGrid.getCellContents(i))
 			{
-				if (colliderA == colliderB) { continue; }
 				potentialPairs.insert({ colliderA, colliderB });
 			}
 		}
 	}
 
 	// Populate with potential pairs from out of bounds.
-	for (auto& colliderA : colliderGrid.getOutBoundContent())
+	for (const auto& colliderA : colliderGrid.getOutBoundContent())
 	{
-		for (auto& colliderB : colliderGrid.getOutBoundContent())
+		for (const auto& colliderB : colliderGrid.getOutBoundContent())
 		{
-			if (colliderA == colliderB) { continue; }
 			potentialPairs.insert({ colliderA, colliderB });
 		}
 	}
 
 	// Invoke onCollide of colliding entity components
-	for (auto collisionPair : potentialPairs)
+	for (const auto& collisionPair : potentialPairs)
 	{
-		// Only invoke one sided, as potentialPairs has symmetric pairs.
-		collision.a = collisionPair.first;
-		collision.b = collisionPair.second;
-		if (getCollisionInfo(collision)) {
-			for (auto component : collision.a->entity->getComponents())
-			{
-				component->onCollide(*collision.b);
-				component->onCollide(collision);
+		if (collisionPair.first != collisionPair.second) 
+		{
+			// Only invoke one sided, as potentialPairs has symmetric pairs.
+			collision.a = collisionPair.first;
+			collision.b = collisionPair.second;
+			if (getCollisionInfo(collision)) {
+				for (auto component : collision.a->entity->getComponents())
+				{
+					component->onCollide(*collision.b);
+					component->onCollide(collision);
+				}
 			}
 		}
 	}

--- a/src/ColliderSystem.cpp
+++ b/src/ColliderSystem.cpp
@@ -36,50 +36,75 @@ void ColliderSystem::deregisterCollider(Collider* collider)
 	colliderGrid.removeCollider(collider);
 }
 
+//------------------- Collision invocation ---------------------//
+
+// Custom hash functions for pair of colliders
+template<typename T>
+void hashCombine(std::size_t& seed, T const& key) {
+	// TODO: somewhat arbitrary from stackoverflow. 
+	// https://stackoverflow.com/questions/28367913/how-to-stdhash-an-unordered-stdpair
+	// Run testing for potential better hashing?
+	std::hash<T> hasher;
+	seed ^= hasher(key) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+template<typename T1, typename T2>
+struct PairHash {
+	std::size_t operator()(std::pair<T1, T2> const& p) const {
+		std::size_t seed(0);
+		::hashCombine(seed, p.first);
+		::hashCombine(seed, p.second);
+
+		return seed;
+	}
+};
+
 void SimpleECS::ColliderSystem::invokeCollisions()
 {
 	colliderGrid.updateGrid();
 	Collision collision = {};
 
-	// TODO: Repeats collision calculations. More repeats if objects span more than one
-	// grid.
+	// Set of potential collision pairs
+	// NOTE: This is populated by potential pairs to collider INTENTIONALLY WITH ORDERING
+	// I.e. (c1, c2) and (c2, c1) are considered different pairs as "onCollision" calls
+	// themselves are ordered and resolved in the perspective of the object itself.
+	std::unordered_set<std::pair<Collider*, Collider*>, PairHash<Collider*, Collider*>>
+		potentialPairs;
+
+	// Populate with potential pairs from main scene
 	for (int i = 0; i < colliderGrid.size(); ++i)
 	{
 		for (auto& colliderA : colliderGrid.getCellContents(i))
 		{
 			for (auto& colliderB : colliderGrid.getCellContents(i))
 			{
-				if (colliderA == colliderB) continue;
-				collision.a = colliderA;
-				collision.b = colliderB;
-				if (getCollisionInfo(collision))
-				{
-					// Invoke onCollide of colliding entity components
-					for (auto component : colliderA->entity->getComponents())
-					{
-						component->onCollide(*colliderB);
-						component->onCollide(collision);
-					}
-				}
+				if (colliderA == colliderB) { continue; }
+				potentialPairs.insert({ colliderA, colliderB });
 			}
 		}
 	}
 
+	// Populate with potential pairs from out of bounds.
 	for (auto& colliderA : colliderGrid.getOutBoundContent())
 	{
 		for (auto& colliderB : colliderGrid.getOutBoundContent())
 		{
-			if (colliderA == colliderB) continue;
-			collision.a = colliderA;
-			collision.b = colliderB;
-			if (getCollisionInfo(collision))
+			if (colliderA == colliderB) { continue; }
+			potentialPairs.insert({ colliderA, colliderB });
+		}
+	}
+
+	// Invoke onCollide of colliding entity components
+	for (auto collisionPair : potentialPairs)
+	{
+		// Only invoke one sided, as potentialPairs has symmetric pairs.
+		collision.a = collisionPair.first;
+		collision.b = collisionPair.second;
+		if (getCollisionInfo(collision)) {
+			for (auto component : collision.a->entity->getComponents())
 			{
-				// Invoke onCollide of colliding entity components
-				for (auto component : colliderA->entity->getComponents())
-				{
-					component->onCollide(*colliderB);
-					component->onCollide(collision);
-				}
+				component->onCollide(*collision.b);
+				component->onCollide(collision);
 			}
 		}
 	}

--- a/src/ColliderSystem.cpp
+++ b/src/ColliderSystem.cpp
@@ -32,6 +32,8 @@ void ColliderSystem::deregisterCollider(Collider* collider)
 			++iter;
 		}
 	}
+
+	colliderGrid.removeCollider(collider);
 }
 
 void SimpleECS::ColliderSystem::invokeCollisions()
@@ -39,6 +41,8 @@ void SimpleECS::ColliderSystem::invokeCollisions()
 	colliderGrid.updateGrid();
 	Collision collision = {};
 
+	// TODO: Repeats collision calculations. More repeats if objects span more than one
+	// grid.
 	for (int i = 0; i < colliderGrid.size(); ++i)
 	{
 		for (auto& colliderA : colliderGrid.getCellContents(i))

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -89,9 +89,12 @@ void Game::mainLoop()
 				component->update();
 			};
 		}
-		
+
 		// Run collision functions
 		ColliderSystem::invokeCollisions();
+
+		// Delete objects
+		sceneList[0]->DestroyAllMarkedEntities();
 
 		// Mark end of frame
 		Timer::endFrame();

--- a/src/PhysicsBody.cpp
+++ b/src/PhysicsBody.cpp
@@ -14,6 +14,15 @@ void SimpleECS::PhysicsBody::onCollide(const Collider& other)
 
 void SimpleECS::PhysicsBody::onCollide(const Collision& collide)
 {
+	// TODO:
+	// Eventaully collision resolution needs to all occur at the SAME TIME AT END OF FRAME
+	// i.e. setting first before getting. 
+	// 
+	// Consider two physics body going towards each other in
+	// in a collision. If the first body's velocity is set from collision resolution
+	// before the second resolves its collision, the second will resolve as if the first was already
+	// flying away.
+	
 	// Shift position out of overlap
 	entity->transform.position.x += (collide.normal * collide.penetration).x;
 	entity->transform.position.y += (collide.normal * collide.penetration).y;

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -18,7 +18,7 @@ bool Scene::AddEntity(Entity* entity)
 	return false;
 }
 
-bool Scene::DestroyEntity(Entity* entityToDelete)
+bool Scene::DestroyEntityImmediate(Entity* entityToDelete)
 {
 	// Scene can only delete an entity it contains
 	if (entities.find(entityToDelete) != entities.end())
@@ -30,4 +30,26 @@ bool Scene::DestroyEntity(Entity* entityToDelete)
 	}
 
 	return false;
+}
+
+bool SIMPLEECS_API SimpleECS::Scene::DestroyEntity(Entity* entityToDelete)
+{
+	// Scene can only delete an entity it contains
+	if (entities.find(entityToDelete) != entities.end())
+	{
+		entities.erase(entityToDelete);
+		toDestroyEntities.insert(entityToDelete);
+
+		return true;
+	}
+	return false;
+}
+
+void SimpleECS::Scene::DestroyAllMarkedEntities()
+{
+	for (auto it = toDestroyEntities.begin(); it != toDestroyEntities.end();)
+	{
+		delete (*it);
+		it = toDestroyEntities.erase(it);
+	}
 }


### PR DESCRIPTION
- DestroyImmediate and Destroy.
  - lazy Destroy needed due to potential hanging references during a frame.

- Fixes multiple issues odd observations with collision
  - Collisions were previously occasionally duplicated if two colliders both spanning multiple grids collide. Can result in buggy behavior.
  - To resolve, keep track of unique collision pairs and their reflection.
- Note: collisions can appear odd due to complete absence of velocity and momentum calculations